### PR TITLE
Fix release workflow: use secrets.token instead of github.token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,4 +64,4 @@ jobs:
         run: |
           gh release create v${{ needs.detect-version.outputs.newVersion }} -t v${{ needs.detect-version.outputs.newVersion }} --target main
         env:
-          GH_TOKEN: ${{ github.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
Using github.TOKEN prevents workflows that trigger on release to work