### PR TITLE
Create shebangify script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ts-wol": "build/index.js"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && chmod +x ./src/scripts/shebangify.sh && ./src/scripts/shebangify.sh",
     "clean": "tsc --build --clean",
     "lint": "eslint --ext .ts .",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { program } from 'commander'
 import { createSocket } from 'dgram'
 import logger from './logger'

--- a/src/scripts/shebangify.sh
+++ b/src/scripts/shebangify.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Inserts the nodejs shebang in build/index.js after compilation
+
+sed -i '1  i #!/usr/bin/env node' build/index.js


### PR DESCRIPTION
Removed the nodejs shebang from `index.ts` and created `shebangify.sh`, a shell script that inserts the nodejs shebang into `build/index.js` post-compilation.